### PR TITLE
fix(JWT-4269): dummy commit to trigger a new build

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -15,7 +15,7 @@ env:
   # when running from the command line.
   # `installAtEnd` and `deployAtEnd` are only effective with recent version of the corresponding plugins.
   MAVEN_CLI_OPTS: "--batch-mode --errors --fail-at-end --show-version -DinstallAtEnd=true -DdeployAtEnd=true"
-  # The maintenance git tag prefix
+  # The maintenance git tag prefix - should narrow down the tags used by the semantic version plugin
   JWT_TAG_PREFIX: 'maintenance_1_x-'
 
 jobs:


### PR DESCRIPTION
before the build, we created not only a git tag, but also a github release